### PR TITLE
Fix broken demo image URL in 0.34.0 data (use committed raw-GitHub reference)

### DIFF
--- a/GatherPress-demo-data-0.34.0.xml
+++ b/GatherPress-demo-data-0.34.0.xml
@@ -359,7 +359,7 @@ Commenter avatars come from <a href="https://gravatar.com/">Gravatar</a>.]]></wp
   <content:encoded><![CDATA[<!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"65%"} -->
 <div class="wp-block-column" style="flex-basis:65%"><!-- wp:image -->
-<figure class="wp-block-image"><img src="https://gatherpress.lndo.site/wp-content/uploads/2024/06/gatherpress-events-list-block-inserter.png" alt="" /></figure>
+<figure class="wp-block-image"><img src="https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/2024/06/gatherpress-events-list-block-inserter.png" alt="" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
@@ -2574,7 +2574,7 @@ Commenter avatars come from <a href="https://gravatar.com/">Gravatar</a>.]]></wp
   <link>https://gatherpress.lndo.site/events/gatherpress-events-list-block-inserter/</link>
   <pubDate>Tue, 11 Jun 2024 11:49:23 +0000</pubDate>
   <dc:creator>admin</dc:creator>
-  <guid isPermaLink="false">https://gatherpress.lndo.site/wp-content/uploads/2024/06/gatherpress-events-list-block-inserter.png</guid>
+  <guid isPermaLink="false">https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/2024/06/gatherpress-events-list-block-inserter.png</guid>
   <description/>
   <content:encoded><![CDATA[]]></content:encoded>
   <excerpt:encoded><![CDATA[]]></excerpt:encoded>
@@ -2592,7 +2592,7 @@ Commenter avatars come from <a href="https://gravatar.com/">Gravatar</a>.]]></wp
   <wp:post_type>attachment</wp:post_type>
   <wp:post_password/>
   <wp:is_sticky>0</wp:is_sticky>
-  <wp:attachment_url>https://gatherpress.lndo.site/wp-content/uploads/2024/06/gatherpress-events-list-block-inserter.png</wp:attachment_url>
+  <wp:attachment_url>https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/2024/06/gatherpress-events-list-block-inserter.png</wp:attachment_url>
   <wp:postmeta>
     <wp:meta_key>_wp_attached_file</wp:meta_key>
     <wp:meta_value><![CDATA[2024/06/gatherpress-events-list-block-inserter.png]]></wp:meta_value>


### PR DESCRIPTION
The `0.34.0` demo data referenced `gatherpress-events-list-block-inserter.png` via a local media-library upload path (`gatherpress.lndo.site/wp-content/uploads/2024/06/...`) instead of the committed `raw.githubusercontent.com` URL this repo uses for every image (see the README note: *"Images can only be referenced by URL, that's why I added them to this repo and used the raw.githubusercontent.com-URLs"*).

## Why it broke

- `base_site_url` in this export is `gatherpress.lndo.site`, so the WXR importer rewrites the image's `/wp-content/uploads/...` path to a **non-existent Playground upload path** (attachments aren't fetched).
- Separately, the browser **CORS-fails** fetching `gatherpress.lndo.site` directly (it's a local dev host), producing the console errors seen in every Playground that imports this data.

Net: a broken image + console spam in the w.org, PR-preview, e2e, and screenshot Playgrounds.

## Fix

Point the three references — inline `<img src>`, attachment `<guid>`, and `<wp:attachment_url>` — at the committed raw-GitHub file:

```
https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/2024/06/gatherpress-events-list-block-inserter.png
```

This matches exactly how the working `0.33.0` export handles the same image. The raw URL returns **HTTP 200** (`image/png`). Because it's now off the `base_site_url` domain, the importer leaves it untouched and it loads.

## Scope

Intentionally **image-only**. The remaining `gatherpress.lndo.site` site-permalink / `base_site_url` URLs are left as-is — the importer rewrites `base_site_url` on import so they're cosmetic, and picking a canonical placeholder domain (the older files use `gatherpress.test`) is a separate, repo-wide decision across all four XML files.

> Note: this only fixes the broken image/CORS noise. It is **not** expected to fix the separate "new Event has no pattern modal" report (GatherPress#1790) — that pattern modal works from a source install; the Playground symptom looks like editor boot-state, though a JS error from this failed image fetch during editor init is one possible contributor worth ruling out after this lands.